### PR TITLE
fix: Switch code() to interactive stream-json mode and run CLI as non-root

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: boxlite-labs/claudebox-runtime
+  IMAGE_NAME: boxlite-ai/claudebox-runtime
 
 jobs:
   build-and-push:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build-image publish-image install test lint format clean help
 
 # Configuration
-IMAGE := ghcr.io/boxlite-labs/claudebox-runtime
+IMAGE := ghcr.io/boxlite-ai/claudebox-runtime
 VERSION := $(shell grep 'version = ' pyproject.toml | head -1 | cut -d'"' -f2)
 
 help:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -88,7 +88,7 @@ If you prefer containerized development:
 
 ```bash
 # Pull the ClaudeBox runtime image
-docker pull ghcr.io/boxlite-labs/claudebox-runtime:latest
+docker pull ghcr.io/boxlite-ai/claudebox-runtime:latest
 
 # Use with ClaudeBox Python API
 python3 -c "from claudebox import ClaudeBox; print('Ready!')"

--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -47,7 +47,7 @@ ClaudeBox provides **6 built-in templates**:
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:latest
+ghcr.io/boxlite-ai/claudebox-runtime:latest
 ```
 
 **When to use:**
@@ -79,7 +79,7 @@ async def default_example():
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:web-dev
+ghcr.io/boxlite-ai/claudebox-runtime:web-dev
 ```
 
 **When to use:**
@@ -130,7 +130,7 @@ await box.code("Create a full-stack app: React frontend + Express backend")
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:data-science
+ghcr.io/boxlite-ai/claudebox-runtime:data-science
 ```
 
 **When to use:**
@@ -191,7 +191,7 @@ await box.code("Create Jupyter notebook for exploratory analysis")
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:security
+ghcr.io/boxlite-ai/claudebox-runtime:security
 ```
 
 **When to use:**
@@ -246,7 +246,7 @@ await box.code("Decode base64-encoded flag from file")
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:devops
+ghcr.io/boxlite-ai/claudebox-runtime:devops
 ```
 
 **When to use:**
@@ -300,7 +300,7 @@ await box.code("Create Ansible playbook to configure web servers")
 
 **Docker Image:**
 ```
-ghcr.io/boxlite-labs/claudebox-runtime:mobile
+ghcr.io/boxlite-ai/claudebox-runtime:mobile
 ```
 
 **When to use:**
@@ -438,7 +438,7 @@ async def main():
 **1. Create Dockerfile:**
 ```dockerfile
 # Start from ClaudeBox base
-FROM ghcr.io/boxlite-labs/claudebox-runtime:latest
+FROM ghcr.io/boxlite-ai/claudebox-runtime:latest
 
 # Install custom tools
 RUN apt-get update && apt-get install -y \
@@ -479,7 +479,7 @@ async def main():
 ### Example: Custom ML Research Template
 
 ```dockerfile
-FROM ghcr.io/boxlite-labs/claudebox-runtime:data-science
+FROM ghcr.io/boxlite-ai/claudebox-runtime:data-science
 
 # Additional ML frameworks
 RUN pip3 install \
@@ -664,13 +664,13 @@ for name, description in templates.items():
 
 **Error:**
 ```
-Error pulling image 'ghcr.io/boxlite-labs/claudebox-runtime:web-dev'
+Error pulling image 'ghcr.io/boxlite-ai/claudebox-runtime:web-dev'
 ```
 
 **Solution:**
 ```bash
 # Pull image manually
-docker pull ghcr.io/boxlite-labs/claudebox-runtime:web-dev
+docker pull ghcr.io/boxlite-ai/claudebox-runtime:web-dev
 
 # Verify image exists
 docker images | grep claudebox

--- a/examples/01_basic_usage.py
+++ b/examples/01_basic_usage.py
@@ -9,6 +9,7 @@ This demonstrates the fundamental features of ClaudeBox:
 """
 
 import asyncio
+import logging
 
 from claudebox import ClaudeBox
 
@@ -171,4 +172,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/02_skills.py
+++ b/examples/02_skills.py
@@ -9,6 +9,7 @@ This demonstrates how to use pre-built and custom skills:
 """
 
 import asyncio
+import logging
 
 from claudebox import (
     API_SKILL,
@@ -293,4 +294,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/03_templates.py
+++ b/examples/03_templates.py
@@ -8,6 +8,7 @@ This demonstrates how to use pre-configured sandbox templates:
 """
 
 import asyncio
+import logging
 
 from claudebox import (
     ClaudeBox,
@@ -144,7 +145,7 @@ async def example_template_string():
     # You can use template string directly
     async with ClaudeBox(
         session_id="string-template",
-        template="ghcr.io/boxlite-labs/claudebox-runtime:latest",
+        template="ghcr.io/boxlite-ai/claudebox-runtime:latest",
     ) as box:
         print(f"Using template string directly")
         print(f"  Box ID: {box.id}")
@@ -157,7 +158,7 @@ async def example_custom_image():
     print("\n=== Example 9: Custom Docker Image ===")
 
     # Use a completely custom image
-    custom_image = "ghcr.io/boxlite-labs/claudebox-runtime:latest"
+    custom_image = "ghcr.io/boxlite-ai/claudebox-runtime:latest"
 
     async with ClaudeBox(
         session_id="custom-image", image=custom_image
@@ -177,7 +178,7 @@ async def example_image_overrides_template():
     async with ClaudeBox(
         session_id="override-example",
         template=SandboxTemplate.WEB_DEV,  # This is ignored
-        image="ghcr.io/boxlite-labs/claudebox-runtime:latest",  # This is used
+        image="ghcr.io/boxlite-ai/claudebox-runtime:latest",  # This is used
     ) as box:
         print(f"Image parameter takes priority over template")
         print(f"  Box ID: {box.id}")
@@ -207,7 +208,7 @@ async def example_get_template_image():
     print(f"  {web_dev_image}")
 
     # Works with string too
-    ds_image = get_template_image("ghcr.io/boxlite-labs/claudebox-runtime:data-science")
+    ds_image = get_template_image("ghcr.io/boxlite-ai/claudebox-runtime:data-science")
     print(f"\nData Science image URL:")
     print(f"  {ds_image}")
 
@@ -250,4 +251,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/04_rl_rewards.py
+++ b/examples/04_rl_rewards.py
@@ -9,6 +9,7 @@ This demonstrates:
 """
 
 import asyncio
+import logging
 
 from claudebox import (
     BuiltinRewards,
@@ -393,4 +394,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/05_security.py
+++ b/examples/05_security.py
@@ -9,6 +9,7 @@ This demonstrates:
 """
 
 import asyncio
+import logging
 
 from claudebox import (
     READONLY_POLICY,
@@ -393,4 +394,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/06_advanced.py
+++ b/examples/06_advanced.py
@@ -9,6 +9,7 @@ This demonstrates advanced usage patterns:
 """
 
 import asyncio
+import logging
 
 from claudebox import (
     API_SKILL,
@@ -431,4 +432,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -295,7 +295,7 @@ Complex workflows and production patterns:
 8. **Template as String**
    ```python
    async with ClaudeBox(
-       template="ghcr.io/boxlite-labs/claudebox-runtime:latest"
+       template="ghcr.io/boxlite-ai/claudebox-runtime:latest"
    ) as box:
        ...
    ```
@@ -303,7 +303,7 @@ Complex workflows and production patterns:
 9. **Custom Docker Images**
    ```python
    async with ClaudeBox(
-       image="ghcr.io/boxlite-labs/claudebox-runtime:custom"
+       image="ghcr.io/boxlite-ai/claudebox-runtime:custom"
    ) as box:
        ...
    ```

--- a/examples/computer_use.py
+++ b/examples/computer_use.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 import asyncio
+import logging
 
 from claudebox import ClaudeBox
 
@@ -28,4 +29,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/examples/persistent_session.py
+++ b/examples/persistent_session.py
@@ -6,6 +6,7 @@ Sessions persist across program runs, maintaining workspace state.
 """
 
 import asyncio
+import logging
 
 from claudebox import ClaudeBox
 
@@ -58,4 +59,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
     asyncio.run(main())

--- a/image/build.sh
+++ b/image/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 VERSION=${1:-latest}
-IMAGE="ghcr.io/boxlite-labs/claudebox-runtime"
+IMAGE="ghcr.io/boxlite-ai/claudebox-runtime"
 
 echo "Building $IMAGE:$VERSION..."
 docker build -t "$IMAGE:$VERSION" .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "boxlite>=0.4.4",
+    "boxlite>=0.5.9",
 ]
 
 [project.optional-dependencies]

--- a/src/claudebox/templates.py
+++ b/src/claudebox/templates.py
@@ -8,12 +8,12 @@ from enum import Enum
 class SandboxTemplate(str, Enum):
     """Pre-configured sandbox templates for different use cases."""
 
-    DEFAULT = "ghcr.io/boxlite-labs/claudebox-runtime:latest"
-    WEB_DEV = "ghcr.io/boxlite-labs/claudebox-runtime:web-dev"
-    DATA_SCIENCE = "ghcr.io/boxlite-labs/claudebox-runtime:data-science"
-    SECURITY = "ghcr.io/boxlite-labs/claudebox-runtime:security"
-    DEVOPS = "ghcr.io/boxlite-labs/claudebox-runtime:devops"
-    MOBILE = "ghcr.io/boxlite-labs/claudebox-runtime:mobile"
+    DEFAULT = "ghcr.io/boxlite-ai/claudebox-runtime:latest"
+    WEB_DEV = "ghcr.io/boxlite-ai/claudebox-runtime:web-dev"
+    DATA_SCIENCE = "ghcr.io/boxlite-ai/claudebox-runtime:data-science"
+    SECURITY = "ghcr.io/boxlite-ai/claudebox-runtime:security"
+    DEVOPS = "ghcr.io/boxlite-ai/claudebox-runtime:devops"
+    MOBILE = "ghcr.io/boxlite-ai/claudebox-runtime:mobile"
 
     def __str__(self) -> str:
         return self.value
@@ -42,7 +42,7 @@ def get_template_image(template: SandboxTemplate | str) -> str:
     """
     if isinstance(template, str):
         # Allow custom image URLs
-        if template.startswith("ghcr.io/") or template.startswith("docker.io/"):
+        if "/" in template and ("." in template.split("/")[0]):
             return template
         # Try to match to enum
         try:

--- a/tests/test_real_templates.py
+++ b/tests/test_real_templates.py
@@ -62,7 +62,7 @@ async def test_03_template_string(ensure_oauth_token, temp_workspace):
             oauth_token=ensure_oauth_token,
             workspace_dir=temp_workspace,
             session_id="template-test-string",
-            template="ghcr.io/boxlite-labs/claudebox-runtime:latest",
+            template="ghcr.io/boxlite-ai/claudebox-runtime:latest",
         ) as box:
             assert box.id
             print("   ✅ Template string works")
@@ -84,7 +84,7 @@ async def test_04_explicit_image_overrides_template(ensure_oauth_token, temp_wor
             workspace_dir=temp_workspace,
             session_id="template-test-override",
             template=SandboxTemplate.WEB_DEV,  # This should be ignored
-            image="ghcr.io/boxlite-labs/claudebox-runtime:latest",  # This takes priority
+            image="ghcr.io/boxlite-ai/claudebox-runtime:latest",  # This takes priority
         ) as box:
             assert box.id
             print("   ✅ Explicit image parameter takes priority")
@@ -170,7 +170,7 @@ async def test_08_custom_image_url(ensure_oauth_token, temp_workspace):
             oauth_token=ensure_oauth_token,
             workspace_dir=temp_workspace,
             session_id="template-custom-url",
-            template="ghcr.io/boxlite-labs/claudebox-runtime:latest",
+            template="ghcr.io/boxlite-ai/claudebox-runtime:latest",
         ) as box:
             assert box.id
             print("   ✅ Custom image URL works")


### PR DESCRIPTION
## Summary

- **Switch `code()` from broken one-shot mode to interactive stream-json mode** — one-shot (`-p prompt`) does not stream stdout through BoxLite's pipe-based exec; interactive mode sends prompt via stdin as NDJSON and streams responses correctly
- **Create non-root user in VM** — Claude CLI v2.0.76 rejects `--dangerously-skip-permissions` when running as root (the default in BoxLite VMs); now creates a `claude` user and wraps all CLI calls with `su -c`
- **Add debug logging and fix test mocks** — diagnostic logging throughout `code()`, proper NDJSON mock output, and `AsyncMock` for `runtime.create()`

## Root Cause

Diagnosed via `test_oneshot_vs_interactive.py` running inside a real BoxLite VM:

| Mode | As Root | As Non-Root |
|------|---------|-------------|
| One-shot (`-p prompt`) | Rejected | 0 stdout chunks (hangs) |
| Interactive (`stream-json`) | Rejected | Works (3 chunks streamed) |

## Changes

| File | Change |
|------|--------|
| `src/claudebox/box.py` | Rewrite `code()` to interactive mode; add `_setup_claude_user()`, `_build_claude_cmd()`; update `_start_claude()` |
| `tests/conftest.py` | Add stdin mock, fix stdout NDJSON format, `AsyncMock` for `runtime.create` |
| `examples/*.py` | Add `logging.basicConfig()` for visible debug output |

## Test plan

- [x] All 99 unit/integration tests pass (`pytest tests/ -v`)
- [x] Ruff lint + format clean on changed files
- [ ] Run `python examples/01_basic_usage.py` with `CLAUDE_CODE_OAUTH_TOKEN` set — verify log output and successful `code()` completion